### PR TITLE
Class name case misspelling in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ use PayPalCheckoutSdk\Core\SandboxEnvironment;
 $clientId = "<<PAYPAL-CLIENT-ID>>";
 $clientSecret = "<<PAYPAL-CLIENT-SECRET>>";
 
-$environment = new SandBoxEnvironment($clientId, $clientSecret);
+$environment = new SandboxEnvironment($clientId, $clientSecret);
 $client = new PayPalHttpClient($environment);
 ```
 


### PR DESCRIPTION
'SandBoxEnvironment' should be 'SandboxEnvironment'