### PR TITLE
Shipping preference misspelling.

### DIFF
--- a/samples/AuthorizeIntentExamples/CreateOrder.php
+++ b/samples/AuthorizeIntentExamples/CreateOrder.php
@@ -25,7 +25,7 @@ class CreateOrder
                     'brand_name' => 'EXAMPLE INC',
                     'locale' => 'en-US',
                     'landing_page' => 'BILLING',
-                    'shipping_preferences' => 'SET_PROVIDED_ADDRESS',
+                    'shipping_preference' => 'SET_PROVIDED_ADDRESS',
                     'user_action' => 'PAY_NOW',
                 ),
             'purchase_units' =>

--- a/samples/CaptureIntentExamples/CreateOrder.php
+++ b/samples/CaptureIntentExamples/CreateOrder.php
@@ -27,7 +27,7 @@ class CreateOrder
                     'brand_name' => 'EXAMPLE INC',
                     'locale' => 'en-US',
                     'landing_page' => 'BILLING',
-                    'shipping_preferences' => 'SET_PROVIDED_ADDRESS',
+                    'shipping_preference' => 'SET_PROVIDED_ADDRESS',
                     'user_action' => 'PAY_NOW',
                 ),
             'purchase_units' =>


### PR DESCRIPTION
PayPal v2 Orders API documentation has this enum option as the singular
"shipping_preference".