### PR TITLE
OAuth - adding target subject to the generate access token…

### DIFF
--- a/lib/PayPalCheckoutSdk/Core/AccessTokenRequest.php
+++ b/lib/PayPalCheckoutSdk/Core/AccessTokenRequest.php
@@ -20,6 +20,10 @@ class AccessTokenRequest extends HttpRequest
             $body["refresh_token"] = $refreshToken;
         }
 
+		if ($environment->getTargetSubject() != null) {
+			$body["target_subject"] = $environment->getTargetSubject();
+		}
+
         $this->body = $body;
         $this->headers["Content-Type"] = "application/x-www-form-urlencoded";
     }

--- a/lib/PayPalCheckoutSdk/Core/PayPalEnvironment.php
+++ b/lib/PayPalCheckoutSdk/Core/PayPalEnvironment.php
@@ -8,16 +8,29 @@ abstract class PayPalEnvironment implements Environment
 {
     private $clientId;
     private $clientSecret;
+	private $targetSubject;
 
-    public function __construct($clientId, $clientSecret)
+    public function __construct($clientId, $clientSecret, $targetSubject = null)
     {
         $this->clientId = $clientId;
         $this->clientSecret = $clientSecret;
+        $this->targetSubject = $targetSubject;
     }
 
     public function authorizationString()
     {
         return base64_encode($this->clientId . ":" . $this->clientSecret);
     }
+
+	public function setTargetSubject($targetSubject)
+	{
+		$this->targetSubject = (string)$targetSubject;
+		return $this;
+	}
+
+	public function getTargetSubject()
+	{
+		return $this->targetSubject;
+	}
 }
 

--- a/lib/PayPalCheckoutSdk/Core/ProductionEnvironment.php
+++ b/lib/PayPalCheckoutSdk/Core/ProductionEnvironment.php
@@ -4,9 +4,9 @@ namespace PayPalCheckoutSdk\Core;
 
 class ProductionEnvironment extends PayPalEnvironment
 {
-    public function __construct($clientId, $clientSecret)
+    public function __construct($clientId, $clientSecret, $targetSubject = null)
     {
-        parent::__construct($clientId, $clientSecret);
+        parent::__construct($clientId, $clientSecret, $targetSubject);
     }
 
     public function baseUrl()

--- a/lib/PayPalCheckoutSdk/Core/SandboxEnvironment.php
+++ b/lib/PayPalCheckoutSdk/Core/SandboxEnvironment.php
@@ -4,9 +4,9 @@ namespace PayPalCheckoutSdk\Core;
 
 class SandboxEnvironment extends PayPalEnvironment
 {
-    public function __construct($clientId, $clientSecret)
+    public function __construct($clientId, $clientSecret, $targetSubject = null)
     {
-        parent::__construct($clientId, $clientSecret);
+        parent::__construct($clientId, $clientSecret, $targetSubject);
     }
 
     public function baseUrl()


### PR DESCRIPTION
fixes #32 Adds target token to OAuth via environment.
Needed to make paypal calls in behalf of another party.